### PR TITLE
setup-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ To easily open source the raw data provided by the
 
 ## Local Developer Install
 ```cmd
-python -m pip install -e . '[dev]'
+python -m pip install -e .'[dev]'
 ```
 To run the test kit
 ```cmd
-pytest tests.py
+python -m pytest tests.py
 ```
 
 ## Usage
@@ -27,9 +27,13 @@ To build the SQLite database after installing the project use the CLI command
 ```cmd
 va-lis
 ```
+If you receive a `command not found` error, try restarting your shell.
+```cmd
+exec "$SHELL"
+```
 This will build the SQLite database!
 
 Then to run the app locally
 ```cmd
-datasette lis.db -o
+python -m datasette lis.db -o
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.7"
 dependencies = [
     "datasette",
+    "sqlite_utils",
 ]
 classifiers = [
     "Framework :: Datasette",


### PR DESCRIPTION
Had to make a few tweaks to get this working for me. I'm using a fresh install of 3.13 and needed to install one extra dependency. I'm using pyenv which I think explains why I had to run pytest and datasette via python -m instead of it being globally available.